### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/hacker2m80/46035c38-398e-40be-8caf-f84920b78b5f/3f80fa3d-8885-40db-a68d-767db31b294f/_apis/work/boardbadge/bd7a91fa-b8fc-475f-9af5-389ce5cf006b)](https://dev.azure.com/hacker2m80/46035c38-398e-40be-8caf-f84920b78b5f/_boards/board/t/3f80fa3d-8885-40db-a68d-767db31b294f/Microsoft.RequirementCategory)
 # Project Name
 
 The DevOps open hack event is designed to foster learning via implementing DevOps practices with a series of challenges.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/hacker2m80/46035c38-398e-40be-8caf-f84920b78b5f/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.